### PR TITLE
Fix AI assistant error 405

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -434,6 +434,6 @@ export async function GET(request: Request) {
       )
       .all(project_id);
 
-    return NextResponse.json(history);
+    return history;
   });
 }


### PR DESCRIPTION
Fix 405 error in AI assistant's GET handler by removing redundant `NextResponse.json` wrapping.

The `GET` handler in `app/api/chat/route.ts` was returning `NextResponse.json(history)`, while the `withErrorHandling` function already wraps the result in `NextResponse.json()`, leading to a double-encapsulation and a 405 error. This change aligns the GET handler's behavior with the POST handler.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9d6bf11-85e8-485d-ba0a-c557ac192cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9d6bf11-85e8-485d-ba0a-c557ac192cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

